### PR TITLE
Update meta info for fork

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -1,11 +1,10 @@
 <?php
 /**
- * Plugin Name: WP REST API
- * Description: JSON-based REST API for WordPress, developed as part of GSoC 2013.
+ * Plugin Name: WP REST API (Sparkart Fork)
+ * Description: A Sparkart fork of the official JSON-based REST API for WordPress.
  * Version: 1.2.1
- * Author: WP REST API Team
+ * Author: WP REST API Team, Sparkart Team
  * Author URI: http://wp-api.org/
- * Plugin URI: https://github.com/WP-API/WP-API
  */
 
 /**


### PR DESCRIPTION
Update the meta info for our fork so we don't accidentally switch forks via the WordPress dashboard

@pushred I think this is a good idea so that WordPress doesn't search for updates and find updates on the WP-API/WP-API master, since those wouldn't include our changes, they shouldn't be available as updates from within WordPress.

If you agree, I'll merge this, and tag a release on our fork before I install on production.

I was looking into best practices for versioning forks, and I didn't really see much of a consensus. It probably doesn't matter much here anyway. I figure we should keep the version number on our fork the same as the main project, just so it's clear what point we forked it from.
