### PR TITLE
add offset to api whitelist

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -116,7 +116,7 @@ class WP_JSON_Posts {
 			$valid_vars = array_merge( $valid_vars, $private );
 		}
 		// Define our own in addition to WP's normal vars
-		$json_valid = array( 'posts_per_page' );
+		$json_valid = array( 'posts_per_page', 'offset' );
 		$valid_vars = array_merge( $valid_vars, $json_valid );
 		// Filter and flip for querying
 		$valid_vars = apply_filters( 'json_query_vars', $valid_vars );


### PR DESCRIPTION
since a lot of our sites depend on offset, we're adding this to the response. when we switch over to the core WP-API we should authenticate instead to access the offset parameter
