### PR TITLE
Remove Link header from /wp-json/posts

### DIFF
--- a/lib/class-wp-json-posts.php
+++ b/lib/class-wp-json-posts.php
@@ -148,7 +148,8 @@ class WP_JSON_Posts {
 			if ( ! json_check_post_permission( $post, 'read' ) ) {
 				continue;
 			}
-			$response->link_header( 'item', json_url( '/posts/' . $post['ID'] ), array( 'title' => $post['post_title'] ) );
+			// The generated Link header is too large, and we don't really need it
+			// $response->link_header( 'item', json_url( '/posts/' . $post['ID'] ), array( 'title' => $post['post_title'] ) );
 			$post_data = $this->prepare_post( $post, $context );
 			if ( is_wp_error( $post_data ) ) {
 				continue;


### PR DESCRIPTION
The Link header generated on the `/wp-json/posts` endpoint can be very large and break Apache (see [Pagely issue](https://support.pagely.com/hc/en-us/requests/135283)). Since we don't use the header, this pull request disables that feature.